### PR TITLE
feat: Validate & Get Inputs Directory [ASB07] 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,6 @@ tmp
 .eslintrc.cjs
 .env
 postgres
+jest.config.ts
+src/scripts/inputs/*
+src/scripts/execute.ts

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 tmp
 .env
 postgres
+src/scripts/inputs/*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run lint:fix
+npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 temp
 .env
+src/scripts/inputs/*

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "build": "rm -rf dist && tsc",
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --fix --max-warnings=0 .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test:unit": "jest --testMatch='**/*.spec.ts' --testPathPattern"
   },
   "dependencies": {
     "inversify": "^6.0.1",

--- a/src/scripts/__tests__/validate-and-get-inputs-directory.spec.ts
+++ b/src/scripts/__tests__/validate-and-get-inputs-directory.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import {
   ValidateAndGetInputsDirectory,
   filesInputDirectory,
-  fileExtension,
+  FileExtension,
 } from '../validate-and-get-inputs-directory';
 import { InputFileName } from '../execute';
 
@@ -12,10 +12,6 @@ describe('ValidateAndGetInputsDirectory', () => {
   let INPUT_DIRECTORY: string;
   const directory = './inputs';
   const testInputsDirectory = path.join(__dirname, directory);
-
-  beforeEach(async () => {
-    await cleanFilesDirectory();
-  });
 
   afterEach(async () => {
     await cleanFilesDirectory();
@@ -58,15 +54,15 @@ describe('ValidateAndGetInputsDirectory', () => {
       INPUT_DIRECTORY = './__tests__/inputs';
       await createFilesDirectory(inputFileName);
       const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(INPUT_DIRECTORY, inputFileName);
-      const validateAndGetInputs = await validateAndGetInputsDirectory.validateAndGetInputs();
+      const response = await validateAndGetInputsDirectory.validateAndGetInputsDirectory();
       const getInputsDirectory: filesInputDirectory = {
         inputsDirectory: testInputsDirectory,
         fileInputs: {
-          txtFile: `${inputFileName}${fileExtension.txt}`,
-          jsonFile: `${inputFileName}${fileExtension.json}`,
+          txtFile: `${inputFileName}${FileExtension.txt}`,
+          jsonFile: `${inputFileName}${FileExtension.json}`,
         },
       };
-      expect(validateAndGetInputs).toEqual(getInputsDirectory);
+      expect(response).toEqual(getInputsDirectory);
     });
   }
 
@@ -77,7 +73,7 @@ describe('ValidateAndGetInputsDirectory', () => {
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Unable to find path directory');
   });
 
@@ -87,19 +83,19 @@ describe('ValidateAndGetInputsDirectory', () => {
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Directory is empty');
   });
 
   it('should throw if directory has only one file', async () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
-    await deleteFile(`${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    await deleteFile(`${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     INPUT_DIRECTORY = './__tests__/inputs';
     const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Unable to process only one file');
   });
 
@@ -111,31 +107,31 @@ describe('ValidateAndGetInputsDirectory', () => {
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Unable to process more than two files');
   });
 
   it('should throw if directory files are under wrong extension', async () => {
     INPUT_DIRECTORY = './__tests__/inputs';
-    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}.md`);
     const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Files under wrong extension');
   });
 
   it('should throw if directory files are under wrong naming', async () => {
     INPUT_DIRECTORY = './__tests__/inputs';
-    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/wrong-naming.json`);
     const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
     await expect(response).rejects.toThrow('Files under wrong naming');
   });
 });

--- a/src/scripts/__tests__/validate-and-get-inputs-directory.spec.ts
+++ b/src/scripts/__tests__/validate-and-get-inputs-directory.spec.ts
@@ -1,0 +1,141 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  ValidateAndGetInputsDirectory,
+  filesInputDirectory,
+  fileExtension,
+} from '../validate-and-get-inputs-directory';
+import { InputFileName } from '../execute';
+
+describe('ValidateAndGetInputsDirectory', () => {
+  let INPUT_DIRECTORY: string;
+  const directory = './inputs';
+  const testInputsDirectory = path.join(__dirname, directory);
+
+  beforeEach(async () => {
+    await cleanFilesDirectory();
+  });
+
+  afterEach(async () => {
+    await cleanFilesDirectory();
+  });
+
+  async function cleanFilesDirectory(): Promise<void> {
+    const files = await readFiles();
+    files.map((file) => deleteFile(file));
+  }
+
+  async function readFiles(): Promise<string[]> {
+    return await fs.promises.readdir(testInputsDirectory);
+  }
+
+  async function deleteFile(file: string): Promise<void> {
+    return await fs.promises.unlink(`${testInputsDirectory}/${file}`);
+  }
+
+  async function createFilesDirectory(inputFileName: InputFileName): Promise<void> {
+    for (const inputTestFile of [
+      `${testInputsDirectory}/${inputFileName}.txt`,
+      `${testInputsDirectory}/${inputFileName}.json`,
+    ]) {
+      await writeTestFile(inputTestFile);
+    }
+  }
+
+  async function writeTestFile(inputTestFile: string): Promise<void> {
+    await fs.promises.writeFile(inputTestFile, '');
+  }
+
+  const inputfileNames = [
+    InputFileName.FrequencyResponse,
+    InputFileName.ImpedanceResponse,
+    InputFileName.ImpulseResponse,
+  ];
+
+  for (const inputFileName of inputfileNames) {
+    it('validates and gets inputs directory', async () => {
+      INPUT_DIRECTORY = './__tests__/inputs';
+      await createFilesDirectory(inputFileName);
+      const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(INPUT_DIRECTORY, inputFileName);
+      const validateAndGetInputs = await validateAndGetInputsDirectory.validateAndGetInputs();
+      const getInputsDirectory: filesInputDirectory = {
+        inputsDirectory: testInputsDirectory,
+        fileInputs: {
+          txtFile: `${inputFileName}${fileExtension.txt}`,
+          jsonFile: `${inputFileName}${fileExtension.json}`,
+        },
+      };
+      expect(validateAndGetInputs).toEqual(getInputsDirectory);
+    });
+  }
+
+  it('should throw if directory does not exist', async () => {
+    await createFilesDirectory(InputFileName.FrequencyResponse);
+    INPUT_DIRECTORY = './unexisting_inputs';
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Unable to find path directory');
+  });
+
+  it('should throw if directory is empty', async () => {
+    INPUT_DIRECTORY = './__tests__/inputs';
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Directory is empty');
+  });
+
+  it('should throw if directory has only one file', async () => {
+    await createFilesDirectory(InputFileName.FrequencyResponse);
+    await deleteFile(`${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    INPUT_DIRECTORY = './__tests__/inputs';
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Unable to process only one file');
+  });
+
+  it('should throw if directory has more than 2 files', async () => {
+    await createFilesDirectory(InputFileName.FrequencyResponse);
+    await createFilesDirectory(InputFileName.ImpedanceResponse);
+    INPUT_DIRECTORY = './__tests__/inputs';
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Unable to process more than two files');
+  });
+
+  it('should throw if directory files are under wrong extension', async () => {
+    INPUT_DIRECTORY = './__tests__/inputs';
+    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}.md`);
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Files under wrong extension');
+  });
+
+  it('should throw if directory files are under wrong naming', async () => {
+    INPUT_DIRECTORY = './__tests__/inputs';
+    await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${fileExtension.txt}`);
+    await writeTestFile(`${testInputsDirectory}/wrong-naming.json`);
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+      INPUT_DIRECTORY,
+      InputFileName.FrequencyResponse,
+    );
+    const response = validateAndGetInputsDirectory.validateAndGetInputs();
+    await expect(response).rejects.toThrow('Files under wrong naming');
+  });
+});

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -11,7 +11,10 @@ export enum InputFileName {
 // execute().catch((err) => console.log(err));
 async function execute() {
   try {
-    await new ValidateAndGetInputsDirectory(INPUTS_DIRECTORY, InputFileName.ImpulseResponse).validateAndGetInputs();
+    await new ValidateAndGetInputsDirectory(
+      INPUTS_DIRECTORY,
+      InputFileName.ImpulseResponse,
+    ).validateAndGetInputsDirectory();
   } catch (error) {
     console.log(error);
   }

--- a/src/scripts/execute.ts
+++ b/src/scripts/execute.ts
@@ -1,0 +1,18 @@
+import { ValidateAndGetInputsDirectory } from './validate-and-get-inputs-directory';
+
+const INPUTS_DIRECTORY = 'inputs';
+
+export enum InputFileName {
+  ImpulseResponse = 'impulse_response',
+  FrequencyResponse = 'frequency_response',
+  ImpedanceResponse = 'impedance_response',
+}
+
+// execute().catch((err) => console.log(err));
+async function execute() {
+  try {
+    await new ValidateAndGetInputsDirectory(INPUTS_DIRECTORY, InputFileName.ImpulseResponse).validateAndGetInputs();
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/scripts/validate-and-get-inputs-directory.ts
+++ b/src/scripts/validate-and-get-inputs-directory.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { InputFileName } from './execute';
+
+export enum fileExtension {
+  txt = '.txt',
+  json = '.json',
+}
+
+interface FileInputs {
+  txtFile: string;
+  jsonFile: string;
+}
+
+export interface filesInputDirectory {
+  inputsDirectory: string;
+  fileInputs: FileInputs;
+}
+
+export class ValidateAndGetInputsDirectory {
+  constructor(private readonly inputsDirectory: string, private readonly inputFileName: InputFileName) {
+    this.inputsDirectory = path.join(__dirname, inputsDirectory);
+  }
+
+  async validateAndGetInputs(): Promise<filesInputDirectory> {
+    await this.validateDirectory();
+    await this.validateContentDirectory();
+    const files = await this.validateAndGetFiles();
+    const { txtFile, jsonFile } = files;
+    return {
+      inputsDirectory: this.inputsDirectory,
+      fileInputs: {
+        txtFile: txtFile,
+        jsonFile: jsonFile,
+      },
+    };
+  }
+
+  private async validateDirectory(): Promise<void> {
+    if (!fs.existsSync(this.inputsDirectory)) throw new Error(`Unable to find path directory`);
+    const directory = await fs.promises.lstat(this.inputsDirectory);
+    if (!directory.isDirectory()) throw new Error(`Expected path is not a directory`);
+  }
+
+  private async validateContentDirectory(): Promise<void> {
+    const files = await this.readFilesFromDirectory();
+    if (files.length === 0) throw new Error('Directory is empty');
+    if (files.length === 1) throw new Error('Unable to process only one file');
+    if (files.length > 2) throw Error('Unable to process more than two files');
+  }
+
+  private async readFilesFromDirectory(): Promise<string[]> {
+    return await fs.promises.readdir(this.inputsDirectory);
+  }
+
+  private async validateAndGetFiles(): Promise<FileInputs> {
+    const files = await this.readFilesFromDirectory();
+    const textFiles = files.filter((file) => fileExtension.txt === this.getExtensionFile(file));
+    const jsonFiles = files.filter((file) => fileExtension.json === this.getExtensionFile(file));
+    if (textFiles.length !== 1 || jsonFiles.length !== 1) throw new Error('Files under wrong extension');
+    this.validateFileName(textFiles[0]);
+    this.validateFileName(jsonFiles[0]);
+    return {
+      txtFile: textFiles[0],
+      jsonFile: jsonFiles[0],
+    };
+  }
+
+  private getExtensionFile(file: string): fileExtension {
+    return path.extname(file) as fileExtension;
+  }
+
+  private validateFileName(file: string) {
+    if (!path.parse(file).name.includes(this.inputFileName)) throw new Error('Files under wrong naming');
+  }
+}

--- a/src/scripts/validate-and-get-inputs-directory.ts
+++ b/src/scripts/validate-and-get-inputs-directory.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { InputFileName } from './execute';
 
-export enum fileExtension {
+export enum FileExtension {
   txt = '.txt',
   json = '.json',
 }
@@ -22,10 +22,10 @@ export class ValidateAndGetInputsDirectory {
     this.inputsDirectory = path.join(__dirname, inputsDirectory);
   }
 
-  async validateAndGetInputs(): Promise<filesInputDirectory> {
+  async validateAndGetInputsDirectory(): Promise<filesInputDirectory> {
     await this.validateDirectory();
     await this.validateContentDirectory();
-    const files = await this.validateAndGetFiles();
+    const files = await this.validateAndGetFilePath();
     const { txtFile, jsonFile } = files;
     return {
       inputsDirectory: this.inputsDirectory,
@@ -53,10 +53,10 @@ export class ValidateAndGetInputsDirectory {
     return await fs.promises.readdir(this.inputsDirectory);
   }
 
-  private async validateAndGetFiles(): Promise<FileInputs> {
+  private async validateAndGetFilePath(): Promise<FileInputs> {
     const files = await this.readFilesFromDirectory();
-    const textFiles = files.filter((file) => fileExtension.txt === this.getExtensionFile(file));
-    const jsonFiles = files.filter((file) => fileExtension.json === this.getExtensionFile(file));
+    const textFiles = files.filter((file) => FileExtension.txt === this.getExtensionFile(file));
+    const jsonFiles = files.filter((file) => FileExtension.json === this.getExtensionFile(file));
     if (textFiles.length !== 1 || jsonFiles.length !== 1) throw new Error('Files under wrong extension');
     this.validateFileName(textFiles[0]);
     this.validateFileName(jsonFiles[0]);
@@ -66,8 +66,8 @@ export class ValidateAndGetInputsDirectory {
     };
   }
 
-  private getExtensionFile(file: string): fileExtension {
-    return path.extname(file) as fileExtension;
+  private getExtensionFile(file: string): FileExtension {
+    return path.extname(file) as FileExtension;
   }
 
   private validateFileName(file: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "outDir": "./dist/",
-    "types": ["node", "reflect-metadata"]
+    "types": ["node", "jest", "reflect-metadata"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["./dist/"]
+  "exclude": ["node_modules", "jest.config.ts"]
 }


### PR DESCRIPTION
### Context

- Impulse & Frequency & Impedance response will be pushed to the API via a script in `/scripts` directory.
- We need to have some high level validations of these inputs before calling our API in order to protect our database and avoid useless http requests.

### Solution
 
- Each input will be first validated via `ValidateAndGetInputsDirectory` class.
- This class validates each input via different aspects:
   - The directory path of where these files has to be inserted
   - The number of files inside this directory
   - The extension of each file of this directory
   - The naming of these file directory
 - this class will be executed before trying to decode each `.txt `file

### Notes

Each input is composed of two different file extensions:
- `.txt`
- `.json`

The `.txt` file involves all measurements coming from `DATS` or `REW` software. The `.json` file involves all information regarding which User belongs this input
