### PR TITLE
chore: restructure import directory [ASB12]

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,5 +5,5 @@ tmp
 .env
 postgres
 jest.config.ts
-src/scripts/inputs/*
-src/scripts/execute.ts
+src/imports/measurements/inputs
+src/imports/measurements/execute.ts

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 tmp
 .env
 postgres
-src/scripts/inputs/*
+src/imports/measurements/inputs/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,6 @@ node_modules
 dist
 temp
 .env
-src/scripts/inputs/*
+src/imports/measurements/inputs/*
+src/imports/measurements/
+.eslintignore

--- a/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
+++ b/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {
-  ValidateAndGetInputsDirectory,
+  ValidateAndGetPathInputsDirectory,
   filesInputDirectory,
   FileExtension,
-} from '../validate-and-get-inputs-directory';
+} from '../validate-and-get-path-inputs-directory';
 import { InputFileName } from '../execute';
 
 describe('ValidateAndGetInputsDirectory', () => {
@@ -53,8 +53,8 @@ describe('ValidateAndGetInputsDirectory', () => {
     it('validates and gets inputs directory', async () => {
       INPUT_DIRECTORY = './__tests__/inputs';
       await createFilesDirectory(inputFileName);
-      const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(INPUT_DIRECTORY, inputFileName);
-      const response = await validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+      const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(INPUT_DIRECTORY, inputFileName);
+      const response = await validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
       const getInputsDirectory: filesInputDirectory = {
         inputsDirectory: testInputsDirectory,
         fileInputs: {
@@ -69,21 +69,21 @@ describe('ValidateAndGetInputsDirectory', () => {
   it('should throw if directory does not exist', async () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     INPUT_DIRECTORY = './unexisting_inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Unable to find path directory');
   });
 
   it('should throw if directory is empty', async () => {
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Directory is empty');
   });
 
@@ -91,11 +91,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     await deleteFile(`${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Unable to process only one file');
   });
 
@@ -103,11 +103,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     await createFilesDirectory(InputFileName.ImpedanceResponse);
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Unable to process more than two files');
   });
 
@@ -115,11 +115,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     INPUT_DIRECTORY = './__tests__/inputs';
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}.md`);
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Files under wrong extension');
   });
 
@@ -127,11 +127,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     INPUT_DIRECTORY = './__tests__/inputs';
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/wrong-naming.json`);
-    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
     await expect(response).rejects.toThrow('Files under wrong naming');
   });
 });

--- a/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
+++ b/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {
-  ValidateAndGetPathInputsDirectory,
+  ValidateAndGetInputsDirectoryPath,
   filesInputDirectory,
   FileExtension,
-} from '../validate-and-get-path-inputs-directory';
+} from '../validate-and-get-inputs-directory-path';
 import { InputFileName } from '../execute';
 
 describe('ValidateAndGetInputsDirectory', () => {
@@ -53,8 +53,8 @@ describe('ValidateAndGetInputsDirectory', () => {
     it('validates and gets inputs directory', async () => {
       INPUT_DIRECTORY = './__tests__/inputs';
       await createFilesDirectory(inputFileName);
-      const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(INPUT_DIRECTORY, inputFileName);
-      const response = await validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+      const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(INPUT_DIRECTORY, inputFileName);
+      const response = await validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
       const getInputsDirectory: filesInputDirectory = {
         inputsDirectory: testInputsDirectory,
         fileInputs: {
@@ -69,21 +69,21 @@ describe('ValidateAndGetInputsDirectory', () => {
   it('should throw if directory does not exist', async () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     INPUT_DIRECTORY = './unexisting_inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Unable to find path directory');
   });
 
   it('should throw if directory is empty', async () => {
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Directory is empty');
   });
 
@@ -91,11 +91,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     await deleteFile(`${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Unable to process only one file');
   });
 
@@ -103,11 +103,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     await createFilesDirectory(InputFileName.FrequencyResponse);
     await createFilesDirectory(InputFileName.ImpedanceResponse);
     INPUT_DIRECTORY = './__tests__/inputs';
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Unable to process more than two files');
   });
 
@@ -115,11 +115,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     INPUT_DIRECTORY = './__tests__/inputs';
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}.md`);
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Files under wrong extension');
   });
 
@@ -127,11 +127,11 @@ describe('ValidateAndGetInputsDirectory', () => {
     INPUT_DIRECTORY = './__tests__/inputs';
     await writeTestFile(`${testInputsDirectory}/${InputFileName.FrequencyResponse}${FileExtension.txt}`);
     await writeTestFile(`${testInputsDirectory}/wrong-naming.json`);
-    const validateAndGetInputsDirectory = new ValidateAndGetPathInputsDirectory(
+    const validateAndGetInputsDirectory = new ValidateAndGetInputsDirectoryPath(
       INPUT_DIRECTORY,
       InputFileName.FrequencyResponse,
     );
-    const response = validateAndGetInputsDirectory.validateAndGetPathInputsDirectory();
+    const response = validateAndGetInputsDirectory.validateAndGetInputsDirectoryPath();
     await expect(response).rejects.toThrow('Files under wrong naming');
   });
 });

--- a/src/imports/measurements/execute.ts
+++ b/src/imports/measurements/execute.ts
@@ -1,4 +1,4 @@
-import { ValidateAndGetInputsDirectory } from './validate-and-get-inputs-directory';
+import { ValidateAndGetPathInputsDirectory } from './validate-and-get-path-inputs-directory';
 
 const INPUTS_DIRECTORY = 'inputs';
 
@@ -11,10 +11,10 @@ export enum InputFileName {
 // execute().catch((err) => console.log(err));
 async function execute() {
   try {
-    await new ValidateAndGetInputsDirectory(
+    await new ValidateAndGetPathInputsDirectory(
       INPUTS_DIRECTORY,
       InputFileName.ImpulseResponse,
-    ).validateAndGetInputsDirectory();
+    ).validateAndGetPathInputsDirectory();
   } catch (error) {
     console.log(error);
   }

--- a/src/imports/measurements/execute.ts
+++ b/src/imports/measurements/execute.ts
@@ -1,4 +1,4 @@
-import { ValidateAndGetPathInputsDirectory } from './validate-and-get-path-inputs-directory';
+import { ValidateAndGetInputsDirectoryPath } from './validate-and-get-inputs-directory-path';
 
 const INPUTS_DIRECTORY = 'inputs';
 
@@ -11,10 +11,10 @@ export enum InputFileName {
 // execute().catch((err) => console.log(err));
 async function execute() {
   try {
-    await new ValidateAndGetPathInputsDirectory(
+    await new ValidateAndGetInputsDirectoryPath(
       INPUTS_DIRECTORY,
       InputFileName.ImpulseResponse,
-    ).validateAndGetPathInputsDirectory();
+    ).validateAndGetInputsDirectoryPath();
   } catch (error) {
     console.log(error);
   }

--- a/src/imports/measurements/validate-and-get-inputs-directory-path.ts
+++ b/src/imports/measurements/validate-and-get-inputs-directory-path.ts
@@ -17,12 +17,12 @@ export interface filesInputDirectory {
   fileInputs: FileInputs;
 }
 
-export class ValidateAndGetPathInputsDirectory {
+export class ValidateAndGetInputsDirectoryPath {
   constructor(private readonly inputsDirectory: string, private readonly inputFileName: InputFileName) {
     this.inputsDirectory = path.join(__dirname, inputsDirectory);
   }
 
-  async validateAndGetPathInputsDirectory(): Promise<filesInputDirectory> {
+  async validateAndGetInputsDirectoryPath(): Promise<filesInputDirectory> {
     await this.validateDirectory();
     await this.validateContentDirectory();
     const files = await this.validateAndGetFilePath();

--- a/src/imports/measurements/validate-and-get-path-inputs-directory.ts
+++ b/src/imports/measurements/validate-and-get-path-inputs-directory.ts
@@ -17,12 +17,12 @@ export interface filesInputDirectory {
   fileInputs: FileInputs;
 }
 
-export class ValidateAndGetInputsDirectory {
+export class ValidateAndGetPathInputsDirectory {
   constructor(private readonly inputsDirectory: string, private readonly inputFileName: InputFileName) {
     this.inputsDirectory = path.join(__dirname, inputsDirectory);
   }
 
-  async validateAndGetInputsDirectory(): Promise<filesInputDirectory> {
+  async validateAndGetPathInputsDirectory(): Promise<filesInputDirectory> {
     await this.validateDirectory();
     await this.validateContentDirectory();
     const files = await this.validateAndGetFilePath();


### PR DESCRIPTION
### Background

A few  updates has to be done since we had this talk in Victoria Park. Here is on what we agreed:
- `POST` a new user or `GET` an existing user
- `POST` a new driver or `GET` an existing driver
- `POST` a new measurement

### Solution

We need to decouple each flow in a specific directory to make each type of import more readable  and make the unit tests easier.