### PR TITLE
Error: add unit tests on github actions [ASB16]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,20 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json') }}
       - name: Transpile
         run: npm run build
+  unit-test:
+    runs-on: ubuntu-latest
+    needs: install-deps
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Restore cached dependencies
+        uses: actions/cache@v3
+        id: restore-deps
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json') }}
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-src/imports/measurements/__tests__/inputs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+src/imports/measurements/__tests__/inputs

--- a/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
+++ b/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts
@@ -13,8 +13,13 @@ describe('ValidateAndGetInputsDirectory', () => {
   const directory = './inputs';
   const testInputsDirectory = path.join(__dirname, directory);
 
+  beforeEach(async () => {
+   await createTestInputsDirectory()
+  })
+
   afterEach(async () => {
     await cleanFilesDirectory();
+    await deleteTestInputsDirectory();
   });
 
   async function cleanFilesDirectory(): Promise<void> {
@@ -28,6 +33,18 @@ describe('ValidateAndGetInputsDirectory', () => {
 
   async function deleteFile(file: string): Promise<void> {
     return await fs.promises.unlink(`${testInputsDirectory}/${file}`);
+  }
+
+  async function createTestInputsDirectory(): Promise<void> {
+    if (!fs.existsSync(testInputsDirectory)) {
+      return await fs.promises.mkdir(testInputsDirectory);
+    }
+  }
+
+  async function deleteTestInputsDirectory(): Promise<void> {
+    if (fs.existsSync(testInputsDirectory)) {
+      return fs.promises.rmdir(testInputsDirectory);
+    }
   }
 
   async function createFilesDirectory(inputFileName: InputFileName): Promise<void> {
@@ -63,7 +80,7 @@ describe('ValidateAndGetInputsDirectory', () => {
         },
       };
       expect(response).toEqual(getInputsDirectory);
-    });
+    });    
   }
 
   it('should throw if directory does not exist', async () => {


### PR DESCRIPTION
### Background

- I want to make my unit tests running on github actions.
- here is the file path of my unit test: `/asb-server/src/imports/measurements/__tests__/validate-and-get-inputs-directory.spec.ts`.
- This unit test use the file system module from NodeJS.
- This unit test delete and write file via this module.
- This module write file via this function `await fs.promises.writeFile(inputTestFile, '');`

### Problem

- After running the github Actions on my machine via Act, I found out that `await fs.promises.writeFile(inputTestFile, '');` does not work in the github actions environment.
- As the unit test is not allowed to write on disk, the test cannot be successful

Error message:  `ENOENT: no such file or directory`